### PR TITLE
fix: value="{{field}}" テンプレートがフォーム入力の element.value に反映されない問題を修正

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -659,12 +659,12 @@ export class ElementFragment extends Fragment {
         // テキスト系フォーム入力には element.value も反映してバインディング変更を確実に適用する。
         if (
           name === 'value' &&
-          element.value !== string &&
           ((element instanceof HTMLInputElement &&
             element.type !== 'checkbox' &&
             element.type !== 'radio') ||
             element instanceof HTMLTextAreaElement ||
-            element instanceof HTMLSelectElement)
+            element instanceof HTMLSelectElement) &&
+          element.value !== string
         ) {
           element.value = string;
           this.value = string;

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -656,18 +656,18 @@ export class ElementFragment extends Fragment {
           element.setAttribute(name, string);
         }
         // element.setAttribute('value', ...) は defaultValue のみ更新するため、
-        // テキスト系フォーム入力には element.value も反映してバインディング変更を確実に適用する。
+        // setValue と同じ対象には element.value も反映して DOM と内部状態を揃える。
         if (
           name === 'value' &&
           ((element instanceof HTMLInputElement &&
-            element.type !== 'checkbox' &&
-            element.type !== 'radio') ||
+            this.INPUT_EVENT_TYPES.includes(element.type)) ||
             element instanceof HTMLTextAreaElement ||
-            element instanceof HTMLSelectElement) &&
-          element.value !== string
+            element instanceof HTMLSelectElement)
         ) {
-          element.value = string;
           this.value = string;
+          if (element.value !== string) {
+            element.value = string;
+          }
         }
       }
     }).finally(() => {

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -655,6 +655,20 @@ export class ElementFragment extends Fragment {
         if (element.getAttribute(name) !== string) {
           element.setAttribute(name, string);
         }
+        // element.setAttribute('value', ...) は defaultValue のみ更新するため、
+        // テキスト系フォーム入力には element.value も反映してバインディング変更を確実に適用する。
+        if (
+          name === 'value' &&
+          element.value !== string &&
+          ((element instanceof HTMLInputElement &&
+            element.type !== 'checkbox' &&
+            element.type !== 'radio') ||
+            element instanceof HTMLTextAreaElement ||
+            element instanceof HTMLSelectElement)
+        ) {
+          element.value = string;
+          this.value = string;
+        }
       }
     }).finally(() => {
       this.skipMutationAttributes = false;

--- a/tests/data-fetch-form-input-binding.test.ts
+++ b/tests/data-fetch-form-input-binding.test.ts
@@ -10,6 +10,7 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import Core from '../src/core';
 import Fragment, {ElementFragment} from '../src/fragment';
+import Form from '../src/form';
 import {waitForDomSettled} from './helpers/async';
 
 describe('data-fetch form input binding', () => {
@@ -58,7 +59,7 @@ describe('data-fetch form input binding', () => {
     expect(usernameInput.value).toBe('user@example.com');
   });
 
-  it('Core.setBindingData 後に element.value が反映される', async () => {
+  it('Core.setBindingData で input と textarea の value が反映される', async () => {
     container.innerHTML = `
       <div id="form-container" data-bind='{"title":"","description":""}'>
         <form>
@@ -75,14 +76,18 @@ describe('data-fetch form input binding', () => {
     await waitForDomSettled();
 
     const titleInput = container.querySelector('#title') as HTMLInputElement;
+    const descriptionInput = container.querySelector(
+      '#description',
+    ) as HTMLTextAreaElement;
     expect(titleInput.value).toBe('新しいタイトル');
+    expect(descriptionInput.value).toBe('説明文');
   });
 
-  it('checkbox は element.checked が変化しない（value 属性の直接バインドは対象外）', async () => {
+  it('checkbox は value 属性を更新しても checked は変化しない', async () => {
     container.innerHTML = `
       <div id="cb-container" data-bind='{"enabled":true}'>
         <form>
-          <input id="ssl" name="ssl" type="checkbox" value="true" />
+          <input id="ssl" name="ssl" type="checkbox" value="{{enabled}}" />
         </form>
       </div>
     `;
@@ -94,9 +99,8 @@ describe('data-fetch form input binding', () => {
     await waitForDomSettled();
 
     const checkbox = container.querySelector('#ssl') as HTMLInputElement;
-    // checkbox は value="true" (静的) なので element.setAttribute('value', ...) の対象外
-    // checked 状態はバインドデータと直接連動しない（data-bind + setValue 経由が正規の方法）
     expect(checkbox.value).toBe('true');
+    expect(checkbox.checked).toBe(false);
   });
 
   it('select 要素の value も正しく更新される', async () => {
@@ -121,7 +125,7 @@ describe('data-fetch form input binding', () => {
     expect(selectEl.value).toBe('ADMIN');
   });
 
-  it('fragment.setValue で設定した値は Form.getValues で取得できる', async () => {
+  it('Form.getValues で設定した値を取得できる', async () => {
     container.innerHTML = `
       <div id="fv-container" data-bind='{"name":"","email":""}'>
         <form id="fv-form">
@@ -139,12 +143,13 @@ describe('data-fetch form input binding', () => {
 
     const form = container.querySelector('#fv-form') as HTMLFormElement;
     const formFragment = Fragment.get(form) as ElementFragment;
+    const formValues = Form.getValues(formFragment);
 
     const nameInput = container.querySelector('#fv-name') as HTMLInputElement;
     const emailInput = container.querySelector('#fv-email') as HTMLInputElement;
 
     expect(nameInput.value).toBe('山田太郎');
     expect(emailInput.value).toBe('yamada@example.com');
-    expect(formFragment.getAttribute('name')).toBeNull();
+    expect(formValues).toEqual({name: '山田太郎', email: 'yamada@example.com'});
   });
 });

--- a/tests/data-fetch-form-input-binding.test.ts
+++ b/tests/data-fetch-form-input-binding.test.ts
@@ -1,0 +1,150 @@
+/* @vitest-environment jsdom */
+/**
+ * @fileoverview data-fetch によるフォーム入力バインディングのテスト
+ *
+ * コンテナ要素に data-fetch を設定し、取得データを value="{{field}}" テンプレートで
+ * フォーム入力に反映する際、element.value が正しく更新されることを検証します。
+ * 修正前は element.setAttribute('value', ...) が defaultValue のみ更新し、
+ * element.value が変化しない問題がありました。
+ */
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import Core from '../src/core';
+import Fragment, {ElementFragment} from '../src/fragment';
+import {waitForDomSettled} from './helpers/async';
+
+describe('data-fetch form input binding', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.removeChild(container);
+  });
+
+  it('value="{{field}}" の入力に element.value が反映される', async () => {
+    container.innerHTML = `
+      <div id="settings" data-bind='{"host":"","port":"","username":""}'>
+        <form>
+          <input id="host" name="host" type="text" value="{{host}}" />
+          <input id="port" name="port" type="number" value="{{port}}" />
+          <input id="username" name="username" type="email" value="{{username}}" />
+        </form>
+      </div>
+    `;
+    await Core.scan(container);
+    await waitForDomSettled();
+
+    const div = container.querySelector('#settings') as HTMLElement;
+    await Core.setBindingData(div, {
+      host: 'imap.example.com',
+      port: 993,
+      username: 'user@example.com',
+    });
+    await waitForDomSettled();
+
+    const hostInput = container.querySelector('#host') as HTMLInputElement;
+    const portInput = container.querySelector('#port') as HTMLInputElement;
+    const usernameInput = container.querySelector(
+      '#username',
+    ) as HTMLInputElement;
+
+    expect(hostInput.value).toBe('imap.example.com');
+    expect(portInput.value).toBe('993');
+    expect(usernameInput.value).toBe('user@example.com');
+  });
+
+  it('Core.setBindingData 後に element.value が反映される', async () => {
+    container.innerHTML = `
+      <div id="form-container" data-bind='{"title":"","description":""}'>
+        <form>
+          <input id="title" name="title" type="text" value="{{title}}" />
+          <textarea id="description" name="description">{{description}}</textarea>
+        </form>
+      </div>
+    `;
+    await Core.scan(container);
+    await waitForDomSettled();
+
+    const div = container.querySelector('#form-container') as HTMLElement;
+    await Core.setBindingData(div, {title: '新しいタイトル', description: '説明文'});
+    await waitForDomSettled();
+
+    const titleInput = container.querySelector('#title') as HTMLInputElement;
+    expect(titleInput.value).toBe('新しいタイトル');
+  });
+
+  it('checkbox は element.checked が変化しない（value 属性の直接バインドは対象外）', async () => {
+    container.innerHTML = `
+      <div id="cb-container" data-bind='{"enabled":true}'>
+        <form>
+          <input id="ssl" name="ssl" type="checkbox" value="true" />
+        </form>
+      </div>
+    `;
+    await Core.scan(container);
+    await waitForDomSettled();
+
+    const div = container.querySelector('#cb-container') as HTMLElement;
+    await Core.setBindingData(div, {enabled: true});
+    await waitForDomSettled();
+
+    const checkbox = container.querySelector('#ssl') as HTMLInputElement;
+    // checkbox は value="true" (静的) なので element.setAttribute('value', ...) の対象外
+    // checked 状態はバインドデータと直接連動しない（data-bind + setValue 経由が正規の方法）
+    expect(checkbox.value).toBe('true');
+  });
+
+  it('select 要素の value も正しく更新される', async () => {
+    container.innerHTML = `
+      <div id="select-container" data-bind='{"role":"VIEWER"}'>
+        <form>
+          <select id="role" name="role" value="{{role}}">
+            <option value="ADMIN">管理者</option>
+            <option value="VIEWER">閲覧者</option>
+          </select>
+        </form>
+      </div>
+    `;
+    await Core.scan(container);
+    await waitForDomSettled();
+
+    const div = container.querySelector('#select-container') as HTMLElement;
+    await Core.setBindingData(div, {role: 'ADMIN'});
+    await waitForDomSettled();
+
+    const selectEl = container.querySelector('#role') as HTMLSelectElement;
+    expect(selectEl.value).toBe('ADMIN');
+  });
+
+  it('fragment.setValue で設定した値は Form.getValues で取得できる', async () => {
+    container.innerHTML = `
+      <div id="fv-container" data-bind='{"name":"","email":""}'>
+        <form id="fv-form">
+          <input id="fv-name" name="name" type="text" value="{{name}}" />
+          <input id="fv-email" name="email" type="email" value="{{email}}" />
+        </form>
+      </div>
+    `;
+    await Core.scan(container);
+    await waitForDomSettled();
+
+    const div = container.querySelector('#fv-container') as HTMLElement;
+    await Core.setBindingData(div, {name: '山田太郎', email: 'yamada@example.com'});
+    await waitForDomSettled();
+
+    const form = container.querySelector('#fv-form') as HTMLFormElement;
+    const formFragment = Fragment.get(form) as ElementFragment;
+
+    const nameInput = container.querySelector('#fv-name') as HTMLInputElement;
+    const emailInput = container.querySelector('#fv-email') as HTMLInputElement;
+
+    expect(nameInput.value).toBe('山田太郎');
+    expect(emailInput.value).toBe('yamada@example.com');
+    expect(formFragment.getAttribute('name')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `ElementFragment.setAttribute` で `value` 属性をテキスト系フォーム入力（`input` / `textarea` / `select`）に適用する際、`element.setAttribute('value', ...)` が `defaultValue` しか更新しない問題を修正
- Queue コールバック内で `element.value` と内部キャッシュ `this.value` も合わせて更新するよう変更
- チェックボックス・ラジオボタンは `checked` 状態で制御するため対象外

## 問題の背景

`data-fetch` をコンテナ要素（div など）に設定し、取得したデータをフォーム内の入力フィールドに
`value="{{field}}"` テンプレート式でバインドした場合、ブラウザの仕様上  
`element.setAttribute('value', evaluated)` は `defaultValue` のみを変更し `element.value` は
変更されませんでした。そのため、フォームに表示される値が更新されませんでした。

## 変更箇所

`src/fragment.ts` — `ElementFragment.setAttribute`:

```typescript
// Before（Queue コールバック内）
element.setAttribute(name, string);

// After（追加部分）
element.setAttribute(name, string);
if (
  name === 'value' &&
  element.value !== string &&
  ((element instanceof HTMLInputElement && element.type !== 'checkbox' && element.type !== 'radio') ||
    element instanceof HTMLTextAreaElement ||
    element instanceof HTMLSelectElement)
) {
  element.value = string;
  this.value = string;
}
```

## Test plan

- [x] 新規テスト `tests/data-fetch-form-input-binding.test.ts`（5件）を追加し全件通過を確認
- [x] 既存テスト 274件が全件通過することを確認（合計 279件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)