### PR TITLE
feat: toast の level に success を追加

### DIFF
--- a/src/haori.ts
+++ b/src/haori.ts
@@ -47,7 +47,7 @@ export default class Haori {
    */
   public static async toast(
     message: string,
-    level: 'info' | 'warning' | 'error',
+    level: 'info' | 'warning' | 'error' | 'success',
   ): Promise<void> {
     const toast = document.createElement('div');
     toast.className = `haori-toast haori-toast-${level}`;

--- a/tests/haori.test.ts
+++ b/tests/haori.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Haori from '../src/haori';
+
+describe('Haori.toast', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(['info', 'warning', 'error', 'success'] as const)(
+    'level "%s" でトーストを表示する',
+    async (level) => {
+      const showPopoverSpy = vi.fn();
+      const hidePopoverSpy = vi.fn();
+      HTMLElement.prototype.showPopover = showPopoverSpy;
+      HTMLElement.prototype.hidePopover = hidePopoverSpy;
+
+      Haori.toast('test message', level);
+
+      const toast = document.querySelector(`.haori-toast-${level}`);
+      expect(toast).not.toBeNull();
+      expect(toast?.textContent).toBe('test message');
+      expect(toast?.classList.contains('haori-toast')).toBe(true);
+      expect(showPopoverSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('3秒後にトーストを非表示にして DOM から削除する', async () => {
+    const showPopoverSpy = vi.fn();
+    const hidePopoverSpy = vi.fn();
+    HTMLElement.prototype.showPopover = showPopoverSpy;
+    HTMLElement.prototype.hidePopover = hidePopoverSpy;
+
+    Haori.toast('hello', 'info');
+
+    expect(document.querySelector('.haori-toast')).not.toBeNull();
+
+    vi.advanceTimersByTime(3000);
+
+    expect(hidePopoverSpy).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.haori-toast')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `Haori.toast` の `level` 型に `'success'` を追加
- `haori-toast-success` クラスが付与されるよう対応済み（実装は既存の文字列テンプレート方式）
- 全 level (`info`, `warning`, `error`, `success`) に対するユニットテストを追加

## Test plan
- [ ] `npx vitest run tests/haori.test.ts` がすべてパスすること
- [ ] CI Workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)