### PR TITLE
feat: addMessage でレベル付きメッセージ設定を追加

### DIFF
--- a/src/haori.ts
+++ b/src/haori.ts
@@ -118,18 +118,33 @@ export default class Haori {
     target: HTMLElement | HTMLFormElement,
     message: string,
   ): Promise<void> {
+    return Haori.addMessage(target, message, 'error');
+  }
+
+  /**
+   * メッセージをレベル付きで追加します。
+   *
+   * @param target メッセージを表示する要素
+   * @param message メッセージ
+   * @param level メッセージのレベル（省略可能）
+   */
+  public static addMessage(
+    target: HTMLElement | HTMLFormElement,
+    message: string,
+    level?: 'info' | 'warning' | 'error' | 'success',
+  ): Promise<void> {
     return Queue.enqueue(() => {
       // 仕様: 入力要素の場合は親要素に、フォーム要素の場合はフォーム自身に data-message を付与する。
-      if (target instanceof HTMLFormElement) {
-        target.setAttribute('data-message', message);
-        return;
+      const recipient =
+        target instanceof HTMLFormElement
+          ? target
+          : (target.parentElement ?? target);
+      recipient.setAttribute('data-message', message);
+      if (level !== undefined) {
+        recipient.setAttribute('data-message-level', level);
+      } else {
+        recipient.removeAttribute('data-message-level');
       }
-      if (target.parentElement) {
-        target.parentElement.setAttribute('data-message', message);
-        return;
-      }
-      // 親が無い場合は当該要素に付与（フォールバック）
-      target.setAttribute('data-message', message);
     }, true) as Promise<void>;
   }
 
@@ -141,8 +156,10 @@ export default class Haori {
   public static clearMessages(parent: HTMLElement): Promise<void> {
     return Queue.enqueue(() => {
       parent.removeAttribute('data-message');
+      parent.removeAttribute('data-message-level');
       parent.querySelectorAll('[data-message]').forEach(element => {
         element.removeAttribute('data-message');
+        element.removeAttribute('data-message-level');
       });
     }, true) as Promise<void>;
   }

--- a/tests/haori.test.ts
+++ b/tests/haori.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Haori from '../src/haori';
+
+describe('Haori.addMessage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('入力要素の場合は親要素に data-message を付与する', async () => {
+    const parent = document.createElement('div');
+    const input = document.createElement('input');
+    parent.appendChild(input);
+    document.body.appendChild(parent);
+
+    await Haori.addMessage(input, 'エラー');
+
+    expect(parent.getAttribute('data-message')).toBe('エラー');
+    expect(parent.hasAttribute('data-message-level')).toBe(false);
+  });
+
+  it('level を指定すると data-message-level が付与される', async () => {
+    const parent = document.createElement('div');
+    const input = document.createElement('input');
+    parent.appendChild(input);
+    document.body.appendChild(parent);
+
+    await Haori.addMessage(input, '確認', 'info');
+
+    expect(parent.getAttribute('data-message')).toBe('確認');
+    expect(parent.getAttribute('data-message-level')).toBe('info');
+  });
+
+  it.each(['info', 'warning', 'error', 'success'] as const)(
+    'level "%s" を data-message-level に設定できる',
+    async (level) => {
+      const parent = document.createElement('div');
+      const input = document.createElement('input');
+      parent.appendChild(input);
+      document.body.appendChild(parent);
+
+      await Haori.addMessage(input, 'msg', level);
+
+      expect(parent.getAttribute('data-message-level')).toBe(level);
+    },
+  );
+
+  it('フォーム要素の場合はフォーム自身に data-message を付与する', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+
+    await Haori.addMessage(form, 'フォームエラー', 'error');
+
+    expect(form.getAttribute('data-message')).toBe('フォームエラー');
+    expect(form.getAttribute('data-message-level')).toBe('error');
+  });
+
+  it('親要素がない場合は当該要素自身に付与する', async () => {
+    const input = document.createElement('input');
+
+    await Haori.addMessage(input, '孤立エラー', 'warning');
+
+    expect(input.getAttribute('data-message')).toBe('孤立エラー');
+    expect(input.getAttribute('data-message-level')).toBe('warning');
+  });
+});
+
+describe('Haori.addErrorMessage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('親要素に data-message を付与し、data-message-level は error になる', async () => {
+    const parent = document.createElement('div');
+    const input = document.createElement('input');
+    parent.appendChild(input);
+    document.body.appendChild(parent);
+
+    await Haori.addErrorMessage(input, 'エラー');
+
+    expect(parent.getAttribute('data-message')).toBe('エラー');
+    expect(parent.getAttribute('data-message-level')).toBe('error');
+  });
+});
+
+describe('Haori.clearMessages', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('親要素の data-message と data-message-level を削除する', async () => {
+    const parent = document.createElement('div');
+    parent.setAttribute('data-message', 'msg');
+    parent.setAttribute('data-message-level', 'info');
+    document.body.appendChild(parent);
+
+    await Haori.clearMessages(parent);
+
+    expect(parent.hasAttribute('data-message')).toBe(false);
+    expect(parent.hasAttribute('data-message-level')).toBe(false);
+  });
+
+  it('子要素の data-message と data-message-level も削除する', async () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('div');
+    child.setAttribute('data-message', 'child msg');
+    child.setAttribute('data-message-level', 'error');
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+
+    await Haori.clearMessages(parent);
+
+    expect(child.hasAttribute('data-message')).toBe(false);
+    expect(child.hasAttribute('data-message-level')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `Haori.addMessage(target, message, level?)` を新規追加
  - `level` を指定すると `data-message-level` 属性にレベルを記録
  - `level` 省略時は `data-message-level` を削除
  - 入力要素は親要素に、フォームはフォーム自身に付与する既存の仕様を継承
- `Haori.addErrorMessage` を `addMessage(target, message, 'error')` への委譲に変更（後方互換性を維持）
- `Haori.clearMessages` が `data-message-level` もあわせてクリアするよう更新

## Test plan
- [ ] `npx vitest run tests/haori.test.ts` がすべてパスすること
- [ ] CI Workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)