### PR TITLE
feat: Haori.toast の level をオプション化し aria-live をレベルに応じて切り替え

### DIFF
--- a/src/haori.ts
+++ b/src/haori.ts
@@ -42,19 +42,19 @@ export default class Haori {
    * 通知トーストを表示します。
    *
    * @param message 表示メッセージ
-   * @param level メッセージのレベル（'info' | 'warning' | 'error'）
+   * @param level メッセージのレベル（省略時は 'info'）
    * @return 通知が表示されると解決されるPromise
    */
   public static async toast(
     message: string,
-    level: 'info' | 'warning' | 'error',
+    level: 'info' | 'warning' | 'error' | 'success' = 'info',
   ): Promise<void> {
     const toast = document.createElement('div');
     toast.className = `haori-toast haori-toast-${level}`;
     toast.textContent = message;
     toast.setAttribute('popover', 'manual');
     toast.setAttribute('role', 'status');
-    toast.setAttribute('aria-live', 'polite');
+    toast.setAttribute('aria-live', level === 'error' ? 'assertive' : 'polite');
     document.body.appendChild(toast);
     toast.showPopover();
     setTimeout(() => {

--- a/tests/haori.test.ts
+++ b/tests/haori.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Haori from '../src/haori';
+
+describe('Haori.toast', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+    HTMLElement.prototype.showPopover = vi.fn();
+    HTMLElement.prototype.hidePopover = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('level を省略すると info として扱う', async () => {
+    Haori.toast('msg');
+    const toast = document.querySelector('.haori-toast-info');
+    expect(toast).not.toBeNull();
+    expect(toast?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it.each(['info', 'warning', 'success'] as const)(
+    'level "%s" は aria-live="polite" を設定する',
+    (level) => {
+      Haori.toast('msg', level);
+      const toast = document.querySelector(`.haori-toast-${level}`);
+      expect(toast?.getAttribute('aria-live')).toBe('polite');
+    },
+  );
+
+  it('level "error" は aria-live="assertive" を設定する', () => {
+    Haori.toast('msg', 'error');
+    const toast = document.querySelector('.haori-toast-error');
+    expect(toast?.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('3秒後にトーストを非表示にして DOM から削除する', () => {
+    const hidePopoverSpy = HTMLElement.prototype.hidePopover as ReturnType<typeof vi.fn>;
+    Haori.toast('hello', 'info');
+    expect(document.querySelector('.haori-toast')).not.toBeNull();
+    vi.advanceTimersByTime(3000);
+    expect(hidePopoverSpy).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.haori-toast')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `Haori.toast(message, level?)` の `level` をオプション引数に変更、省略時は `'info'`
- `'success'` レベルを型に追加
- `level === 'error'` のとき `aria-live="assertive"`、それ以外は `"polite"` に設定（スクリーンリーダー対応）

## Test plan
- [ ] `npx vitest run tests/haori.test.ts` がすべてパスすること
- [ ] CI Workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)