### PR TITLE
feat: data-{event}-toast-level 属性でトーストレベルを HTML から指定可能に

### DIFF
--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -229,6 +229,9 @@ export interface ProcedureOptions {
   /** トーストメッセージ */
   toastMessage?: string | null;
 
+  /** トーストレベル */
+  toastLevel?: 'info' | 'warning' | 'error' | 'success' | null;
+
   /** history.pushState で追加する URL */
   historyUrl?: string | null;
 
@@ -822,6 +825,13 @@ ${body}
         options.toastMessage = fragment.getAttribute(
           Procedure.attrName(event, 'toast'),
         ) as string;
+        const rawLevel = fragment.getRawAttribute(
+          Procedure.attrName(event, 'toast-level'),
+        );
+        const validLevels = ['info', 'warning', 'error', 'success'] as const;
+        options.toastLevel = validLevels.includes(rawLevel as (typeof validLevels)[number])
+          ? (rawLevel as (typeof validLevels)[number])
+          : null;
       }
       if (fragment.hasAttribute(Procedure.attrName(event, 'redirect'))) {
         options.redirectUrl = fragment.getAttribute(
@@ -1343,7 +1353,10 @@ ${body}
       await activeHaori.dialog(this.options.dialogMessage);
     }
     if (this.options.toastMessage) {
-      await activeHaori.toast(this.options.toastMessage, 'info');
+      await activeHaori.toast(
+        this.options.toastMessage,
+        this.options.toastLevel ?? 'info',
+      );
     }
     this.pushHistory();
     if (this.options.redirectUrl) {

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -829,9 +829,9 @@ ${body}
           Procedure.attrName(event, 'toast-level'),
         );
         const validLevels = ['info', 'warning', 'error', 'success'] as const;
-        options.toastLevel = validLevels.includes(rawLevel as (typeof validLevels)[number])
-          ? (rawLevel as (typeof validLevels)[number])
-          : null;
+        type ToastLevel = (typeof validLevels)[number];
+        const isValidLevel = validLevels.includes(rawLevel as ToastLevel);
+        options.toastLevel = isValidLevel ? (rawLevel as ToastLevel) : null;
       }
       if (fragment.hasAttribute(Procedure.attrName(event, 'redirect'))) {
         options.redirectUrl = fragment.getAttribute(

--- a/tests/fetch-and-procedure-scenarios.test.ts
+++ b/tests/fetch-and-procedure-scenarios.test.ts
@@ -143,6 +143,44 @@ describe('Fetch and Procedure scenarios', () => {
     btn.remove();
   });
 
+  it('data-click-toast-level でトーストレベルを指定できる', async () => {
+    const Haori = await import('../src/haori');
+    const toastSpy = vi
+      .spyOn(Haori.default, 'toast')
+      .mockResolvedValue(undefined as void);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('data-click-toast', '保存しました');
+    btn.setAttribute('data-click-toast-level', 'success');
+    document.body.appendChild(btn);
+
+    btn.click();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(toastSpy).toHaveBeenCalledWith('保存しました', 'success');
+
+    btn.remove();
+  });
+
+  it('data-click-toast-level に不正な値を指定すると info にフォールバックする', async () => {
+    const Haori = await import('../src/haori');
+    const toastSpy = vi
+      .spyOn(Haori.default, 'toast')
+      .mockResolvedValue(undefined as void);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('data-click-toast', 'msg');
+    btn.setAttribute('data-click-toast-level', 'invalid');
+    document.body.appendChild(btn);
+
+    btn.click();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(toastSpy).toHaveBeenCalledWith('msg', 'info');
+
+    btn.remove();
+  });
+
   it('POST sends JSON body when payload exists', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);


### PR DESCRIPTION
## Summary
- `data-{event}-toast-level` 属性を追加（`data-{event}-toast` とセットで使用）
- 有効値: `info` / `warning` / `error` / `success`
- 省略または不正値の場合は `'info'` にフォールバック

## Usage
```html
<button data-click-toast="保存しました" data-click-toast-level="success">保存</button>
<button data-click-toast="エラーが発生しました" data-click-toast-level="error">送信</button>
```

## Test plan
- [ ] `npx vitest run tests/fetch-and-procedure-scenarios.test.ts` がすべてパスすること
- [ ] CI Workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)