### PR TITLE
feat: Form.addMessage と Haori.addMessage を追加

### DIFF
--- a/src/form.ts
+++ b/src/form.ts
@@ -369,7 +369,7 @@ export default class Form {
    *
    * @param fragment 対象フラグメント
    * @param key キー（ドット区切りの文字列）
-   * @param message 追加するエラーメッセージ]
+   * @param message 追加するエラーメッセージ
    * @return Promise（メッセージの追加が完了したら解決される）
    */
   public static addErrorMessage(
@@ -377,18 +377,39 @@ export default class Form {
     key: string,
     message: string,
   ): Promise<void> {
+    return Form.addMessage(fragment, key, message, 'error');
+  }
+
+  /**
+   * キーに一致するフラグメントにレベル付きメッセージを追加します。
+   * キーに一致するフラグメントが見つからない場合は、指定されたフラグメントにメッセージを追加します。
+   *
+   * @param fragment 対象フラグメント
+   * @param key キー（ドット区切りの文字列）
+   * @param message 追加するメッセージ
+   * @param level メッセージのレベル（省略可能）
+   * @return Promise（メッセージの追加が完了したら解決される）
+   */
+  public static addMessage(
+    fragment: ElementFragment,
+    key: string,
+    message: string,
+    level?: 'info' | 'warning' | 'error' | 'success',
+  ): Promise<void> {
     const promises: Promise<void>[] = [];
     const activeHaori = resolveFormHaoriApi();
+    const addMsgFn = (activeHaori as { addMessage?: typeof Haori.addMessage }).addMessage;
+    const doAdd = (target: HTMLElement): Promise<void> =>
+      typeof addMsgFn === 'function'
+        ? (addMsgFn.call(activeHaori, target, message, level) as Promise<void>)
+        : (activeHaori.addErrorMessage(target, message) as Promise<void>);
+
     const targetFragments = Form.findFragmentsByKey(fragment, key);
     targetFragments.forEach(targetFragment => {
-      promises.push(
-        activeHaori.addErrorMessage(targetFragment.getTarget(), message),
-      );
+      promises.push(doAdd(targetFragment.getTarget() as HTMLElement));
     });
     if (targetFragments.length === 0) {
-      promises.push(
-        activeHaori.addErrorMessage(fragment.getTarget(), message),
-      );
+      promises.push(doAdd(fragment.getTarget() as HTMLElement));
     }
     return Promise.all(promises).then(() => undefined);
   }

--- a/src/form.ts
+++ b/src/form.ts
@@ -398,7 +398,9 @@ export default class Form {
   ): Promise<void> {
     const promises: Promise<void>[] = [];
     const activeHaori = resolveFormHaoriApi();
-    const addMsgFn = (activeHaori as { addMessage?: typeof Haori.addMessage }).addMessage;
+    const addMsgFn = (
+      activeHaori as {addMessage?: typeof Haori.addMessage}
+    ).addMessage;
     const doAdd = (target: HTMLElement): Promise<void> =>
       typeof addMsgFn === 'function'
         ? (addMsgFn.call(activeHaori, target, message, level) as Promise<void>)

--- a/src/haori.ts
+++ b/src/haori.ts
@@ -156,8 +156,10 @@ export default class Haori {
   public static clearMessages(parent: HTMLElement): Promise<void> {
     return Queue.enqueue(() => {
       parent.removeAttribute('data-message');
+      parent.removeAttribute('data-message-level');
       parent.querySelectorAll('[data-message]').forEach(element => {
         element.removeAttribute('data-message');
+        element.removeAttribute('data-message-level');
       });
     }, true) as Promise<void>;
   }

--- a/src/haori.ts
+++ b/src/haori.ts
@@ -118,18 +118,33 @@ export default class Haori {
     target: HTMLElement | HTMLFormElement,
     message: string,
   ): Promise<void> {
+    return Haori.addMessage(target, message, 'error');
+  }
+
+  /**
+   * メッセージをレベル付きで追加します。
+   *
+   * @param target メッセージを表示する要素
+   * @param message メッセージ
+   * @param level メッセージのレベル（省略可能）
+   */
+  public static addMessage(
+    target: HTMLElement | HTMLFormElement,
+    message: string,
+    level?: 'info' | 'warning' | 'error' | 'success',
+  ): Promise<void> {
     return Queue.enqueue(() => {
       // 仕様: 入力要素の場合は親要素に、フォーム要素の場合はフォーム自身に data-message を付与する。
-      if (target instanceof HTMLFormElement) {
-        target.setAttribute('data-message', message);
-        return;
+      const recipient =
+        target instanceof HTMLFormElement
+          ? target
+          : (target.parentElement ?? target);
+      recipient.setAttribute('data-message', message);
+      if (level !== undefined) {
+        recipient.setAttribute('data-message-level', level);
+      } else {
+        recipient.removeAttribute('data-message-level');
       }
-      if (target.parentElement) {
-        target.parentElement.setAttribute('data-message', message);
-        return;
-      }
-      // 親が無い場合は当該要素に付与（フォールバック）
-      target.setAttribute('data-message', message);
     }, true) as Promise<void>;
   }
 

--- a/tests/haori.test.ts
+++ b/tests/haori.test.ts
@@ -44,3 +44,75 @@ describe('Haori.toast', () => {
     expect(document.querySelector('.haori-toast')).toBeNull();
   });
 });
+
+describe('Haori.addMessage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('入力要素の場合は親要素に data-message を付与する', async () => {
+    const parent = document.createElement('div');
+    const input = document.createElement('input');
+    parent.appendChild(input);
+    document.body.appendChild(parent);
+
+    await Haori.addMessage(input, 'エラー');
+
+    expect(parent.getAttribute('data-message')).toBe('エラー');
+    expect(parent.hasAttribute('data-message-level')).toBe(false);
+  });
+
+  it('level を指定すると data-message-level が付与される', async () => {
+    const parent = document.createElement('div');
+    const input = document.createElement('input');
+    parent.appendChild(input);
+    document.body.appendChild(parent);
+
+    await Haori.addMessage(input, '確認', 'info');
+
+    expect(parent.getAttribute('data-message')).toBe('確認');
+    expect(parent.getAttribute('data-message-level')).toBe('info');
+  });
+
+  it.each(['info', 'warning', 'error', 'success'] as const)(
+    'level "%s" を data-message-level に設定できる',
+    async (level) => {
+      const parent = document.createElement('div');
+      const input = document.createElement('input');
+      parent.appendChild(input);
+      document.body.appendChild(parent);
+
+      await Haori.addMessage(input, 'msg', level);
+
+      expect(parent.getAttribute('data-message-level')).toBe(level);
+    },
+  );
+
+  it('フォーム要素の場合はフォーム自身に付与する', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+
+    await Haori.addMessage(form, 'フォームエラー', 'error');
+
+    expect(form.getAttribute('data-message')).toBe('フォームエラー');
+    expect(form.getAttribute('data-message-level')).toBe('error');
+  });
+});
+
+describe('Haori.addErrorMessage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('addMessage("error") に委譲する', async () => {
+    const parent = document.createElement('div');
+    const input = document.createElement('input');
+    parent.appendChild(input);
+    document.body.appendChild(parent);
+
+    await Haori.addErrorMessage(input, 'エラー');
+
+    expect(parent.getAttribute('data-message')).toBe('エラー');
+    expect(parent.getAttribute('data-message-level')).toBe('error');
+  });
+});

--- a/tests/haori.test.ts
+++ b/tests/haori.test.ts
@@ -99,6 +99,40 @@ describe('Haori.addMessage', () => {
   });
 });
 
+describe('Haori.clearMessages', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('data-message と data-message-level を両方除去する', async () => {
+    const parent = document.createElement('div');
+    const input = document.createElement('input');
+    parent.appendChild(input);
+    document.body.appendChild(parent);
+
+    await Haori.addMessage(input, 'エラー', 'error');
+    expect(parent.hasAttribute('data-message-level')).toBe(true);
+
+    await Haori.clearMessages(parent);
+
+    expect(parent.hasAttribute('data-message')).toBe(false);
+    expect(parent.hasAttribute('data-message-level')).toBe(false);
+  });
+
+  it('子要素の data-message-level も除去する', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+
+    await Haori.addMessage(form, 'エラー', 'warning');
+    expect(form.getAttribute('data-message-level')).toBe('warning');
+
+    await Haori.clearMessages(form);
+
+    expect(form.hasAttribute('data-message')).toBe(false);
+    expect(form.hasAttribute('data-message-level')).toBe(false);
+  });
+});
+
 describe('Haori.addErrorMessage', () => {
   beforeEach(() => {
     document.body.innerHTML = '';


### PR DESCRIPTION
## Summary
- `Haori.addMessage(target, message, level?)` を追加
  - `data-message` に加え `data-message-level` 属性でレベルを記録
  - `addErrorMessage` は `addMessage(target, message, 'error')` への委譲に変更
- `Form.addMessage(fragment, key, message, level?)` を追加
  - キーに一致するフラグメントにレベル付きメッセージを設定
  - `window.Haori` が `addMessage` を持たない場合は `addErrorMessage` にフォールバック（後方互換）

## Test plan
- [ ] `npx vitest run` が 298 テストすべてパスすること
- [ ] CI Workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)