### PR TITLE
docs: data-fetch-bind-arg を仕様書・ガイドに追記

### DIFF
--- a/docs/ja/guide.md
+++ b/docs/ja/guide.md
@@ -863,7 +863,11 @@ window.Dates = {
 </div>
 ```
 
-#### `data-fetch-arg`: データをネストするキー名を指定
+#### `data-fetch-arg` / `data-fetch-bind-arg`: データをネストするキー名を指定
+
+レスポンスデータを指定したキー名の下に格納してバインドします。
+`data-fetch-arg` と `data-fetch-bind-arg` は同義で、`data-fetch-arg` が優先されます。
+イベント属性版は `data-{event}-bind-arg` を使用します。
 
 ```html
 <div data-fetch="/api/user" data-fetch-arg="user">
@@ -871,6 +875,11 @@ window.Dates = {
   <!-- user.name, user.email としてアクセスできる -->
   <p>{{user.name}}</p>
   <p>{{user.email}}</p>
+</div>
+
+<!-- data-fetch-bind-arg も同じ意味 -->
+<div data-fetch="/api/user" data-fetch-bind-arg="user">
+  <p>{{user.name}}</p>
 </div>
 ```
 

--- a/docs/ja/specs.md
+++ b/docs/ja/specs.md
@@ -1319,7 +1319,8 @@ data-fetch="url"
 - `data-fetch-data`: 送信データ
 - `data-fetch-form`: フォーム要素のセレクタ
 - `data-fetch-bind`: バインド先セレクタ (デフォルト: 自要素)
-- `data-fetch-arg`: バインドキー名
+- `data-fetch-arg`: バインドキー名（`data-fetch-bind-arg` と同義。こちらが優先）
+- `data-fetch-bind-arg`: バインドキー名（`data-fetch-arg` の別名。`data-fetch-arg` が無い場合に参照）
 - `data-fetch-bind-params`: 抽出パラメータ (&区切り)
 
 **例**:


### PR DESCRIPTION
## Summary
- `data-fetch-bind-arg` が `data-fetch-arg` の別名として動作することを specs.md・guide.md に記載
- 優先順位（`data-fetch-arg` > `data-fetch-bind-arg`）を明記
- イベント版 `data-{event}-bind-arg` との関係も整理

## Background
コードには実装済み ([procedure.ts:700-723](../src/procedure.ts)) だが、ガイド・仕様書にはこれまで `data-fetch-arg` のみ記載されていた。

## Test plan
- [ ] CI Workflow が成功すること（docs のみ変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)