### PR TITLE
feat: data-{event}-scroll-error 属性を追加する

### DIFF
--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -1460,6 +1460,16 @@ ${body}
       await resolveProcedureHaoriApi().addErrorMessage(targetEl, message);
     };
 
+    const scrollToFirstError = () => {
+      if (!this.options.scrollOnError) return;
+      const root = baseFragment ? baseFragment.getTarget() : document.body;
+      const firstError =
+        root.getAttribute('data-message-level') === 'error'
+          ? root
+          : root.querySelector<HTMLElement>('[data-message-level="error"]');
+      firstError?.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+    };
+
     // コンテンツタイプに応じて解析
     const contentType = response.headers.get('Content-Type') || '';
     if (contentType.includes('application/json')) {
@@ -1506,6 +1516,7 @@ ${body}
         if (entries.length === 0) {
           // 汎用メッセージ
           await addGeneralMessage(`${response.status} ${response.statusText}`);
+          scrollToFirstError();
           return false;
         }
         // メッセージを反映
@@ -1516,14 +1527,7 @@ ${body}
             await addGeneralMessage(e.message);
           }
         }
-        if (this.options.scrollOnError) {
-          const root = baseFragment ? baseFragment.getTarget() : document.body;
-          const firstError =
-            root.getAttribute('data-message-level') === 'error'
-              ? root
-              : root.querySelector<HTMLElement>('[data-message-level="error"]');
-          firstError?.scrollIntoView({behavior: 'smooth', block: 'nearest'});
-        }
+        scrollToFirstError();
         return false;
       } catch {
         // JSON 解析失敗時はテキストにフォールバック
@@ -1540,6 +1544,7 @@ ${body}
     } catch {
       await addGeneralMessage(`${response.status} ${response.statusText}`);
     }
+    scrollToFirstError();
     return false;
   }
 

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -1465,11 +1465,15 @@ ${body}
         return;
       }
       const root = baseFragment ? baseFragment.getTarget() : document.body;
-      const firstError =
+      // addErrorMessage はフォーム以外の target に対して parentElement へエラーを付与するため、
+      // root 自身・parentElement・root 配下の順で探索する
+      const errorTarget =
         root.getAttribute('data-message-level') === 'error'
           ? root
-          : root.querySelector<HTMLElement>('[data-message-level="error"]');
-      firstError?.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+          : root.parentElement?.getAttribute('data-message-level') === 'error'
+            ? root.parentElement
+            : root.querySelector<HTMLElement>('[data-message-level="error"]');
+      errorTarget?.scrollIntoView({behavior: 'smooth', block: 'nearest'});
     };
 
     // コンテンツタイプに応じて解析

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -1461,7 +1461,9 @@ ${body}
     };
 
     const scrollToFirstError = () => {
-      if (!this.options.scrollOnError) return;
+      if (!this.options.scrollOnError) {
+        return;
+      }
       const root = baseFragment ? baseFragment.getTarget() : document.body;
       const firstError =
         root.getAttribute('data-message-level') === 'error'

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -1561,22 +1561,39 @@ ${body}
     if (this.options.valid !== true) {
       return true;
     }
-    const target = fragment.getTarget();
-    let result = this.validateOne(fragment);
-    if (!result) {
-      target.focus();
-      if (this.options.scrollOnError) {
-        target.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+    const firstInvalid = this.findFirstInvalid(fragment);
+    if (firstInvalid === null) {
+      return true;
+    }
+    firstInvalid.focus();
+    if (this.options.scrollOnError) {
+      firstInvalid.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+    }
+    return false;
+  }
+
+  /**
+   * 対象フラグメント以下で DOM 順の最上部にある invalid 要素を返します。
+   * 全フラグメントのバリデーションを実行した上で検出のみを行います。
+   *
+   * @param fragment 対象のフラグメント
+   * @returns 最初の invalid 要素、なければ null
+   */
+  private findFirstInvalid(fragment: ElementFragment): HTMLElement | null {
+    // 子要素を逆順に処理することで、DOM 順の先頭要素が最後に found を上書きし、
+    // 最終的に最上部の invalid 要素が返る
+    let found: HTMLElement | null = null;
+    for (const child of fragment.getChildElementFragments().reverse()) {
+      const result = this.findFirstInvalid(child);
+      if (result !== null) {
+        found = result;
       }
     }
-    // エラー要素のフォーカスを最上部に移動するため、子要素は逆順で処理
-    fragment
-      .getChildElementFragments()
-      .reverse()
-      .forEach(child => {
-        result &&= this.validate(child);
-      });
-    return result;
+    // 自身は子より DOM 上位にあるため、invalid なら子の結果を上書きする
+    if (!this.validateOne(fragment)) {
+      return fragment.getTarget();
+    }
+    return found;
   }
 
   /**

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -243,6 +243,9 @@ export interface ProcedureOptions {
 
   /** リダイレクトURL */
   redirectUrl?: string | null;
+
+  /** エラー時に最初のエラー要素へスクロールするかどうか */
+  scrollOnError?: boolean | null;
 }
 
 /**
@@ -837,6 +840,9 @@ ${body}
         options.redirectUrl = fragment.getAttribute(
           Procedure.attrName(event, 'redirect'),
         ) as string;
+      }
+      if (fragment.hasAttribute(Procedure.attrName(event, 'scroll-error'))) {
+        options.scrollOnError = true;
       }
       // history（data-{event}-history / history-data / history-form）
       if (fragment.hasAttribute(Procedure.attrName(event, 'history'))) {
@@ -1510,6 +1516,14 @@ ${body}
             await addGeneralMessage(e.message);
           }
         }
+        if (this.options.scrollOnError) {
+          const root = baseFragment ? baseFragment.getTarget() : document.body;
+          const firstError =
+            root.getAttribute('data-message-level') === 'error'
+              ? root
+              : root.querySelector<HTMLElement>('[data-message-level="error"]');
+          firstError?.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+        }
         return false;
       } catch {
         // JSON 解析失敗時はテキストにフォールバック
@@ -1544,6 +1558,9 @@ ${body}
     let result = this.validateOne(fragment);
     if (!result) {
       target.focus();
+      if (this.options.scrollOnError) {
+        target.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+      }
     }
     // エラー要素のフォーカスを最上部に移動するため、子要素は逆順で処理
     fragment

--- a/tests/procedure-action-operations.test.ts
+++ b/tests/procedure-action-operations.test.ts
@@ -688,6 +688,42 @@ describe('Procedure action operations', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       form.remove();
     });
+
+    it('バリデーション失敗（複数 invalid）: scrollIntoView は先頭の invalid 要素に 1 回だけ呼ばれる', async () => {
+      // reportValidity をスタブして両 input を確実に invalid にする
+      vi.spyOn(HTMLInputElement.prototype, 'reportValidity').mockReturnValue(
+        false,
+      );
+
+      const form = document.createElement('form');
+      const inputA = document.createElement('input'); // DOM 上で先頭
+      inputA.name = 'name';
+      form.appendChild(inputA);
+      const inputB = document.createElement('input'); // DOM 上で 2 番目
+      inputB.name = 'email';
+      form.appendChild(inputB);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('data-click-fetch', 'http://api.test/multi-validate');
+      btn.setAttribute('data-click-form', '');
+      btn.setAttribute('data-click-validate', '');
+      btn.setAttribute('data-click-scroll-error', '');
+      form.appendChild(btn);
+      document.body.appendChild(form);
+
+      await waitForDomSettled();
+      btn.click();
+      await waitForCondition(
+        () => scrollIntoViewSpy.mock.calls.length > 0,
+        {description: 'scrollIntoView called once on first invalid'},
+      );
+
+      // 1 回だけ呼ばれる
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      // 先頭の invalid 要素（inputA）に対して呼ばれる
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(inputA);
+      form.remove();
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/tests/procedure-action-operations.test.ts
+++ b/tests/procedure-action-operations.test.ts
@@ -628,6 +628,39 @@ describe('Procedure action operations', () => {
       form.remove();
     });
 
+    it('non-form target: addErrorMessage が parentElement に付与したエラー要素へ scrollIntoView が呼ばれる', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+        Promise.resolve(
+          new Response('Server Error', {
+            status: 500,
+            headers: {'Content-Type': 'text/plain'},
+          }),
+        ) as unknown as Promise<Response>,
+      );
+
+      // フォームではなく div の中にボタンを置く
+      const container = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('data-click-fetch', 'http://api.test/non-form-error');
+      btn.setAttribute('data-click-scroll-error', '');
+      container.appendChild(btn);
+      document.body.appendChild(container);
+
+      await waitForDomSettled();
+      btn.click();
+      // addErrorMessage は非フォーム target の parentElement にエラーを付与する
+      await waitForCondition(
+        () => container.getAttribute('data-message-level') === 'error',
+        {description: 'error set on parentElement (container)'},
+      );
+
+      // container（btn.parentElement）に対して scrollIntoView が 1 回呼ばれる
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(container);
+      container.remove();
+    });
+
     it('data-click-scroll-error がない場合は scrollIntoView が呼ばれない', async () => {
       vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
         Promise.resolve(

--- a/tests/procedure-action-operations.test.ts
+++ b/tests/procedure-action-operations.test.ts
@@ -511,11 +511,14 @@ describe('Procedure action operations', () => {
   // -----------------------------------------------------------------------
 
   describe('data-click-scroll-error', () => {
-    let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+    let scrollIntoViewSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
-      scrollIntoViewSpy = vi.fn();
-      Element.prototype.scrollIntoView = scrollIntoViewSpy;
+      // jsdom は scrollIntoView を実装していないため先に定義してからスパイする
+      Element.prototype.scrollIntoView = () => {};
+      scrollIntoViewSpy = vi
+        .spyOn(Element.prototype, 'scrollIntoView')
+        .mockImplementation(() => {});
     });
 
     it('JSON フィールドエラー: エラー要素の scrollIntoView が呼ばれる', async () => {

--- a/tests/procedure-action-operations.test.ts
+++ b/tests/procedure-action-operations.test.ts
@@ -507,6 +507,180 @@ describe('Procedure action operations', () => {
   });
 
   // -----------------------------------------------------------------------
+  // data-click-scroll-error
+  // -----------------------------------------------------------------------
+
+  describe('data-click-scroll-error', () => {
+    let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      scrollIntoViewSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoViewSpy;
+    });
+
+    it('JSON フィールドエラー: エラー要素の scrollIntoView が呼ばれる', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({errors: {email: 'メールアドレスが不正です'}}),
+            {status: 422, headers: {'Content-Type': 'application/json'}},
+          ),
+        ) as unknown as Promise<Response>,
+      );
+
+      const form = document.createElement('form');
+      const emailWrapper = document.createElement('div');
+      const emailInput = document.createElement('input');
+      emailInput.name = 'email';
+      emailWrapper.appendChild(emailInput);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('data-click-fetch', 'http://api.test/json-field-error');
+      btn.setAttribute('data-click-scroll-error', '');
+      form.append(emailWrapper, btn);
+      document.body.appendChild(form);
+
+      await waitForDomSettled();
+      btn.click();
+      await waitForCondition(
+        () => emailWrapper.getAttribute('data-message-level') === 'error',
+        {description: 'field error message set'},
+      );
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+      form.remove();
+    });
+
+    it('JSON entries が空（汎用メッセージ）: scrollIntoView が呼ばれる', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+        Promise.resolve(
+          new Response('{}', {
+            status: 500,
+            headers: {'Content-Type': 'application/json'},
+          }),
+        ) as unknown as Promise<Response>,
+      );
+
+      const form = document.createElement('form');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('data-click-fetch', 'http://api.test/json-empty-error');
+      btn.setAttribute('data-click-scroll-error', '');
+      form.appendChild(btn);
+      document.body.appendChild(form);
+
+      await waitForDomSettled();
+      btn.click();
+      await waitForCondition(
+        () => form.getAttribute('data-message-level') === 'error',
+        {description: 'general error message set (json empty)'},
+      );
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+      form.remove();
+    });
+
+    it('text/plain フォールバック: scrollIntoView が呼ばれる', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+        Promise.resolve(
+          new Response('Internal Server Error', {
+            status: 500,
+            headers: {'Content-Type': 'text/plain'},
+          }),
+        ) as unknown as Promise<Response>,
+      );
+
+      const form = document.createElement('form');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('data-click-fetch', 'http://api.test/text-error');
+      btn.setAttribute('data-click-scroll-error', '');
+      form.appendChild(btn);
+      document.body.appendChild(form);
+
+      await waitForDomSettled();
+      btn.click();
+      await waitForCondition(
+        () => form.getAttribute('data-message-level') === 'error',
+        {description: 'text fallback error message set'},
+      );
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+      form.remove();
+    });
+
+    it('data-click-scroll-error がない場合は scrollIntoView が呼ばれない', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+        Promise.resolve(
+          new Response('Error', {
+            status: 500,
+            headers: {'Content-Type': 'text/plain'},
+          }),
+        ) as unknown as Promise<Response>,
+      );
+
+      const form = document.createElement('form');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('data-click-fetch', 'http://api.test/no-scroll');
+      form.appendChild(btn);
+      document.body.appendChild(form);
+
+      await waitForDomSettled();
+      btn.click();
+      await waitForCondition(
+        () => form.getAttribute('data-message-level') === 'error',
+        {description: 'error message set without scroll-error attr'},
+      );
+
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+      form.remove();
+    });
+
+    it('バリデーション失敗: scrollIntoView が呼ばれる', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      const form = document.createElement('form');
+      const input = document.createElement('input');
+      input.name = 'name';
+      input.required = true;
+      input.value = '';
+      form.appendChild(input);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('data-click-fetch', 'http://api.test/validate');
+      btn.setAttribute('data-click-form', '');
+      btn.setAttribute('data-click-validate', '');
+      btn.setAttribute('data-click-scroll-error', '');
+      form.appendChild(btn);
+      document.body.appendChild(form);
+
+      await waitForDomSettled();
+      btn.click();
+      await waitForCondition(
+        () => scrollIntoViewSpy.mock.calls.length > 0,
+        {description: 'scrollIntoView called on validation error'},
+      );
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+      form.remove();
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // history.pushState
   // -----------------------------------------------------------------------
 

--- a/tests/procedure-action-operations.test.ts
+++ b/tests/procedure-action-operations.test.ts
@@ -521,6 +521,13 @@ describe('Procedure action operations', () => {
         .mockImplementation(() => {});
     });
 
+    afterEach(() => {
+      // vi.restoreAllMocks() は直接代入した () => {} へ戻すだけなので、
+      // afterEach でプロパティ自体を削除して jsdom の元の状態（未定義）に戻す
+      delete (Element.prototype as unknown as Record<string, unknown>)
+        .scrollIntoView;
+    });
+
     it('JSON フィールドエラー: エラー要素の scrollIntoView が呼ばれる', async () => {
       vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
         Promise.resolve(


### PR DESCRIPTION
## 概要

フェッチエラー時またはバリデーション失敗時に、画面外にある最初のエラー要素へ自動スクロールする `data-{event}-scroll-error` 属性を追加します。

## 使い方

```html
<button data-click-fetch="/api/submit" data-click-scroll-error>送信</button>
```

## 変更内容

- `ProcedureOptions` に `scrollOnError` フィールドを追加
- `buildOptions()` で `data-{event}-scroll-error` 属性を読み込む
- `handleFetchError()` のエラーループ完了後に1回だけ `scrollIntoView` を実行
- `validate()` でも `scrollOnError` 指定時に `scrollIntoView` を追加

## 複数エラーへの対処

サーバーエラーが複数ある場合でも、`handleFetchError()` のループで全エラーメッセージを設定し終えた**後**に1回だけスクロールするため、連続スクロールが発生しません。