### PR TITLE
fix: data-fetch経由のdata-each内でdata-ifが正常に評価されない問題を修正

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -528,19 +528,7 @@ export default class Core {
       promises.push(Core.evaluateIf(fragment));
     }
     if (fragment.hasAttribute(`${Env.prefix}each`)) {
-      return Promise.all(promises)
-        .then(() => Core.evaluateEach(fragment))
-        .then(() => {
-          const childPromises: Promise<void>[] = [];
-          fragment.getChildren().forEach(child => {
-            if (child instanceof ElementFragment) {
-              childPromises.push(Core.evaluateAll(child));
-            } else if (child instanceof TextFragment) {
-              childPromises.push(Core.evaluateText(child));
-            }
-          });
-          return Promise.all(childPromises).then(() => undefined);
-        });
+      return Promise.all(promises).then(() => Core.evaluateEach(fragment));
     }
     fragment.getChildren().forEach(child => {
       if (child instanceof ElementFragment) {

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -299,6 +299,62 @@ describe('Core', () => {
       expect(items[2].classList.contains('active')).toBe(false);
     });
 
+    test('data-each 配下の a タグに data-if と href プレースホルダが共存する場合に正しく hide/show される', async () => {
+      container.innerHTML = `
+        <table>
+          <tbody
+            data-bind='{"content":[
+              {"id":1,"customerCode":"C001","category":"顧客","billingId":null},
+              {"id":2,"customerCode":"C002","category":"請求","billingId":"B001"},
+              {"id":3,"customerCode":"C003","category":"入金","billingId":null}
+            ]}'
+            data-each="content"
+            data-each-key="id"
+          >
+            <tr>
+              <td>{{customerCode}}</td>
+              <td>{{category}}</td>
+              <td>
+                <a data-if="category === '顧客'" href="customer-list.html?customerCode={{customerCode}}">顧客対応</a>
+                <a data-if="category === '請求'" href="billing-list.html?customerCode={{customerCode}}&amp;billingId={{billingId}}">請求対応</a>
+                <a data-if="category === '入金'" href="payment-list.html?customerCode={{customerCode}}">入金対応</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+
+      const tbody = container.querySelector('tbody') as HTMLElement;
+      await Core.scan(tbody);
+      await waitForDomSettled();
+      await waitForDomSettled();
+      // scheduleEvaluateAll (100ms後) の再評価も待機
+      await new Promise(resolve => setTimeout(resolve, 200));
+      await waitForDomSettled();
+
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      expect(rows).toHaveLength(3);
+
+      const row0Links = Array.from(rows[0].querySelectorAll('a'));
+      const row1Links = Array.from(rows[1].querySelectorAll('a'));
+      const row2Links = Array.from(rows[2].querySelectorAll('a'));
+
+      // row0: category=顧客 → 顧客リンク表示、請求・入金リンク非表示
+      expect(row0Links[0].hasAttribute('data-if-false')).toBe(false);
+      expect(row0Links[1].hasAttribute('data-if-false')).toBe(true);
+      expect(row0Links[2].hasAttribute('data-if-false')).toBe(true);
+
+      // row1: category=請求 → 顧客リンク非表示、請求リンク表示、入金リンク非表示
+      expect(row1Links[0].hasAttribute('data-if-false')).toBe(true);
+      expect(row1Links[1].hasAttribute('data-if-false')).toBe(false);
+      expect(row1Links[2].hasAttribute('data-if-false')).toBe(true);
+
+      // row2: category=入金 → 顧客・請求リンク非表示、入金リンク表示
+      expect(row2Links[0].hasAttribute('data-if-false')).toBe(true);
+      expect(row2Links[1].hasAttribute('data-if-false')).toBe(true);
+      expect(row2Links[2].hasAttribute('data-if-false')).toBe(false);
+    });
+
     test('data-attr-src が生値を維持したまま実属性を再評価する', async () => {
       container.innerHTML = `
         <img

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -2,6 +2,7 @@
  * @fileoverview Coreクラスのテスト
  */
 
+import {vi} from 'vitest';
 import Core from '../src/core';
 import {ElementFragment} from '../src/fragment';
 import {waitForCondition, waitForDomSettled} from './helpers/async';
@@ -343,16 +344,20 @@ describe('Core', () => {
       expect(row0Links[0].hasAttribute('data-if-false')).toBe(false);
       expect(row0Links[1].hasAttribute('data-if-false')).toBe(true);
       expect(row0Links[2].hasAttribute('data-if-false')).toBe(true);
+      // href プレースホルダが行データで展開されていること
+      expect(row0Links[0].getAttribute('href')).toBe('customer-list.html?customerCode=C001');
 
       // row1: category=請求 → 顧客リンク非表示、請求リンク表示、入金リンク非表示
       expect(row1Links[0].hasAttribute('data-if-false')).toBe(true);
       expect(row1Links[1].hasAttribute('data-if-false')).toBe(false);
       expect(row1Links[2].hasAttribute('data-if-false')).toBe(true);
+      expect(row1Links[1].getAttribute('href')).toBe('billing-list.html?customerCode=C002&billingId=B001');
 
       // row2: category=入金 → 顧客・請求リンク非表示、入金リンク表示
       expect(row2Links[0].hasAttribute('data-if-false')).toBe(true);
       expect(row2Links[1].hasAttribute('data-if-false')).toBe(true);
       expect(row2Links[2].hasAttribute('data-if-false')).toBe(false);
+      expect(row2Links[2].getAttribute('href')).toBe('payment-list.html?customerCode=C003');
     });
 
     test('data-attr-src が生値を維持したまま実属性を再評価する', async () => {
@@ -531,5 +536,83 @@ describe('Core', () => {
 
       expect(el.hasAttribute('data-importing')).toBe(false);
     });
+  });
+});
+
+describe('data-fetch + data-each + data-if integration', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  it('data-fetch経由でデータを取得した場合もdata-each内のdata-ifが行ごとに正しく評価される', async () => {
+    const responseData = {
+      content: [
+        {id: 1, customerCode: 'C001', category: '顧客', billingId: null},
+        {id: 2, customerCode: 'C002', category: '請求', billingId: 'B001'},
+        {id: 3, customerCode: 'C003', category: '入金', billingId: null},
+      ],
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(responseData), {
+        headers: {'Content-Type': 'application/json'},
+      }),
+    );
+
+    container.innerHTML = `
+      <section id="alert-list" data-fetch="/api/alerts.json">
+        <table>
+          <tbody data-each="content" data-each-key="id">
+            <tr>
+              <td>
+                <a data-if="category === '顧客'" href="customer-list.html?customerCode={{customerCode}}">顧客対応</a>
+                <a data-if="category === '請求'" href="billing-list.html?customerCode={{customerCode}}&amp;billingId={{billingId}}">請求対応</a>
+                <a data-if="category === '入金'" href="payment-list.html?customerCode={{customerCode}}">入金対応</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    `;
+
+    const section = container.querySelector('section') as HTMLElement;
+    await Core.scan(section);
+    const tbody = container.querySelector('tbody') as HTMLElement;
+    await waitForCondition(
+      () => tbody.querySelectorAll('tr').length === 3,
+      {description: 'tbody rows via fetch'},
+    );
+    // scheduleEvaluateAll (100ms後) の再評価も待機
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    const row0Links = Array.from(rows[0].querySelectorAll('a'));
+    const row1Links = Array.from(rows[1].querySelectorAll('a'));
+    const row2Links = Array.from(rows[2].querySelectorAll('a'));
+
+    // row0: category=顧客 → 顧客リンクのみ表示、href が展開されていること
+    expect(row0Links[0].hasAttribute('data-if-false')).toBe(false);
+    expect(row0Links[0].getAttribute('href')).toBe('customer-list.html?customerCode=C001');
+    expect(row0Links[1].hasAttribute('data-if-false')).toBe(true);
+    expect(row0Links[2].hasAttribute('data-if-false')).toBe(true);
+
+    // row1: category=請求 → 請求リンクのみ表示、href が展開されていること
+    expect(row1Links[0].hasAttribute('data-if-false')).toBe(true);
+    expect(row1Links[1].hasAttribute('data-if-false')).toBe(false);
+    expect(row1Links[1].getAttribute('href')).toBe('billing-list.html?customerCode=C002&billingId=B001');
+    expect(row1Links[2].hasAttribute('data-if-false')).toBe(true);
+
+    // row2: category=入金 → 入金リンクのみ表示、href が展開されていること
+    expect(row2Links[0].hasAttribute('data-if-false')).toBe(true);
+    expect(row2Links[1].hasAttribute('data-if-false')).toBe(true);
+    expect(row2Links[2].hasAttribute('data-if-false')).toBe(false);
+    expect(row2Links[2].getAttribute('href')).toBe('payment-list.html?customerCode=C003');
   });
 });

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -327,11 +327,15 @@ describe('Core', () => {
 
       const tbody = container.querySelector('tbody') as HTMLElement;
       await Core.scan(tbody);
-      await waitForDomSettled();
-      await waitForDomSettled();
-      // scheduleEvaluateAll (100ms後) の再評価も待機
-      await new Promise(resolve => setTimeout(resolve, 200));
-      await waitForDomSettled();
+      await waitForCondition(
+        () => tbody.querySelectorAll('tr').length === 3,
+        {description: 'tbody rows'},
+      );
+      // scheduleEvaluateAll (100ms後) の再評価を待つ: 非表示リンクに data-if-false が付くまで待機
+      await waitForCondition(
+        () => tbody.querySelectorAll('[data-if-false]').length > 0,
+        {description: 'data-if-false applied', delayMs: 50, maxAttempts: 6},
+      );
 
       const rows = Array.from(tbody.querySelectorAll('tr'));
       expect(rows).toHaveLength(3);
@@ -589,8 +593,11 @@ describe('data-fetch + data-each + data-if integration', () => {
       () => tbody.querySelectorAll('tr').length === 3,
       {description: 'tbody rows via fetch'},
     );
-    // scheduleEvaluateAll (100ms後) の再評価も待機
-    await new Promise(resolve => setTimeout(resolve, 200));
+    // scheduleEvaluateAll (100ms後) の再評価を待つ: 非表示リンクに data-if-false が付くまで待機
+    await waitForCondition(
+      () => tbody.querySelectorAll('[data-if-false]').length > 0,
+      {description: 'data-if-false applied via fetch', delayMs: 50, maxAttempts: 6},
+    );
 
     const rows = Array.from(tbody.querySelectorAll('tr'));
     const row0Links = Array.from(rows[0].querySelectorAll('a'));

--- a/tests/helpers/async.ts
+++ b/tests/helpers/async.ts
@@ -18,19 +18,22 @@ export async function waitForDomSettled(cycles = 3): Promise<void> {
  * 条件が満たされるまでキュー処理を進めながら待機します。
  *
  * @param condition 判定関数
- * @param options 最大試行回数と説明
+ * @param options 最大試行回数、説明、各試行前の待機ミリ秒
  * @returns 条件が満たされたら解決されるPromise
  */
 export async function waitForCondition(
   condition: () => boolean,
-  options: {description?: string; maxAttempts?: number} = {},
+  options: {description?: string; maxAttempts?: number; delayMs?: number} = {},
 ): Promise<void> {
-  const {description = 'condition', maxAttempts = 10} = options;
+  const {description = 'condition', maxAttempts = 10, delayMs = 0} = options;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    await waitForDomSettled();
     if (condition()) {
       return;
     }
-    await waitForDomSettled();
   }
   throw new Error(`Timed out waiting for ${description}.`);
 }


### PR DESCRIPTION
## Summary

- `evaluateAll()` の `data-each` 処理後に子要素を再評価するコードを削除
- `data-fetch` でデータ取得後に `data-each` 内の `data-if` が全て表示されてしまうバグを修正

## 原因

`evaluateAll()` の `data-each` 分岐（`core.ts`）で、`evaluateEach()` 完了後にさらに子要素全体を `evaluateAll()` で再評価するコードがあった。

この再評価が `data-fetch` 経由のデータバインド後に実行される場合、`updateDiff` 内で各行の `evaluateAll` が既に正しく完了しているにもかかわらず、追加の評価が行われていた。この追加評価のタイミングで `<tr>` のバインドデータが子要素（`<a data-if="...">`）に正しく伝播しておらず `ReferenceError: category is not defined` が発生、`data-if` が全要素で `undefined` を返して全て表示されてしまっていた。

`updateDiff` 内では各行の `updateRowFragment` → `evaluateAll` を既に呼んでいるため、この追加評価は不要。

## Test plan

- [x] `tests/core.test.ts` に再現テストを追加（`data-each` 配下の `a` タグに `data-if` と `href` プレースホルダが共存するケース）
- [x] 全352テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)