### PR TITLE
fix: MutationObserver経由の展開済み値でattributeMapのテンプレート式が上書きされる問題を修正

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -767,6 +767,15 @@ export class ElementFragment extends Fragment {
       return this.removeAliasedAttribute(rawName, targetName);
     }
     const contents = new AttributeContents(rawName, value);
+    // MutationObserver経由で展開済みの値が渡された場合に、テンプレート式を含む既存エントリを上書きしない。
+    // （例: href="...{{customerCode}}..." が展開された後の値でattributeMapが破壊されるのを防ぐ）
+    const existing = this.attributeMap.get(rawName);
+    if (existing && (existing.isEvaluate || existing.isForceEvaluation()) && !contents.isEvaluate && !contents.isForceEvaluation()) {
+      this.skipMutationAttributes = true;
+      return Queue.enqueue(() => {}).finally(() => {
+        this.skipMutationAttributes = false;
+      }) as Promise<void>;
+    }
     this.attributeMap.set(rawName, contents);
     this.skipMutationAttributes = true;
     const element = this.getTarget();


### PR DESCRIPTION
## 問題

`<a href=...{{customerCode}}...>` のように href にプレースホルダを含む属性を持つ要素において、data-if が常に undefined と評価されて全要素が表示される問題が発生していた。

## 根本原因

1. evaluateAll() が href のプレースホルダを展開して DOM に書き込む
2. MutationObserver がこの変化を検知し、展開済みの値で setAttributeInternal を呼び出す
3. setAttributeInternal 内で attributeMap の href エントリが展開済みの値で上書きされる
4. 次回の evaluateAll() 時にテンプレート式が失われ、バインドデータが参照できなくなる
5. data-if の評価が常に undefined となり、全要素が表示される

## 修正

setAttributeInternal 内で、既存エントリがテンプレート式を含む場合にプレースホルダなしの値による上書きをスキップするガードを追加した。

```typescript
const existing = this.attributeMap.get(rawName);
if (existing && (existing.isEvaluate || existing.isForceEvaluation()) && !contents.isEvaluate && !contents.isForceEvaluation()) {
  this.skipMutationAttributes = true;
  return Queue.enqueue(() => {}).finally(() => {
    this.skipMutationAttributes = false;
  }) as Promise<void>;
}
```

## 影響範囲

href, src 等にプレースホルダを含む要素で、同一要素に data-if や data-each 等のバインド属性が共存する場合に発生していた問題を修正。

Generated with Claude Code