### PR TITLE
fix: MutationObserver経由の展開済み値でattributeMapのテンプレート式が上書きされる問題を修正

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -242,7 +242,9 @@ export default class Core {
       if (value === null) {
         return fragment.removeAliasedAttribute(name, aliasedAttributeName);
       }
-      return fragment.setAliasedAttribute(name, aliasedAttributeName, value);
+      return fragment.setAliasedAttribute(
+        name, aliasedAttributeName, value, fromObserver,
+      );
     }
     const promises: Promise<void>[] = [];
     switch (name) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -234,6 +234,7 @@ export default class Core {
     element: HTMLElement,
     name: string,
     value: string | null,
+    fromObserver = false,
   ): Promise<void> {
     const fragment = Fragment.get(element);
     const aliasedAttributeName = Core.getAliasedAttributeName(name);
@@ -323,7 +324,7 @@ export default class Core {
     if (value === null) {
       promises.push(fragment.removeAttribute(name));
     } else {
-      promises.push(fragment.setAttribute(name, value));
+      promises.push(fragment.setAttribute(name, value, fromObserver));
     }
     return Promise.all(promises).then(() => undefined);
   }

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -695,8 +695,12 @@ export class ElementFragment extends Fragment {
    * @param value 属性値
    * @returns 属性の更新のPromise
    */
-  public setAttribute(name: string, value: string | null): Promise<void> {
-    return this.setAttributeInternal(name, name, value, true);
+  public setAttribute(
+    name: string,
+    value: string | null,
+    fromObserver = false,
+  ): Promise<void> {
+    return this.setAttributeInternal(name, name, value, true, fromObserver);
   }
 
   /**
@@ -756,6 +760,7 @@ export class ElementFragment extends Fragment {
     targetName: string,
     value: string | null,
     syncValueProperty: boolean,
+    fromObserver = false,
   ): Promise<void> {
     if (this.skipMutationAttributes) {
       return Promise.resolve();
@@ -767,17 +772,21 @@ export class ElementFragment extends Fragment {
       return this.removeAliasedAttribute(rawName, targetName);
     }
     const contents = new AttributeContents(rawName, value);
-    // MutationObserver経由で展開済みの値が渡された場合に、テンプレート式を含む既存エントリを上書きしない。
-    // （例: href="...{{customerCode}}..." が展開された後の値でattributeMapが破壊されるのを防ぐ）
-    const existing = this.attributeMap.get(rawName);
-    const existingHasTemplate = existing
-      && (existing.isEvaluate || existing.isForceEvaluation());
-    const newHasTemplate = contents.isEvaluate || contents.isForceEvaluation();
-    if (existingHasTemplate && !newHasTemplate) {
-      this.skipMutationAttributes = true;
-      return Queue.enqueue(() => {}).finally(() => {
-        this.skipMutationAttributes = false;
-      }) as Promise<void>;
+    if (fromObserver) {
+      // MutationObserver経由の書き戻し（展開済み値）でテンプレート式を含む既存エントリを上書きしない。
+      // （例: href="...{{customerCode}}..." が展開された後にObserverが展開済み値を再セットするのを防ぐ）
+      const existing = this.attributeMap.get(rawName);
+      if (
+        existing &&
+        (existing.isEvaluate || existing.isForceEvaluation()) &&
+        !contents.isEvaluate &&
+        !contents.isForceEvaluation()
+      ) {
+        this.skipMutationAttributes = true;
+        return Queue.enqueue(() => {}).finally(() => {
+          this.skipMutationAttributes = false;
+        }) as Promise<void>;
+      }
     }
     this.attributeMap.set(rawName, contents);
     this.skipMutationAttributes = true;

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -770,7 +770,10 @@ export class ElementFragment extends Fragment {
     // MutationObserver経由で展開済みの値が渡された場合に、テンプレート式を含む既存エントリを上書きしない。
     // （例: href="...{{customerCode}}..." が展開された後の値でattributeMapが破壊されるのを防ぐ）
     const existing = this.attributeMap.get(rawName);
-    if (existing && (existing.isEvaluate || existing.isForceEvaluation()) && !contents.isEvaluate && !contents.isForceEvaluation()) {
+    const existingHasTemplate = existing
+      && (existing.isEvaluate || existing.isForceEvaluation());
+    const newHasTemplate = contents.isEvaluate || contents.isForceEvaluation();
+    if (existingHasTemplate && !newHasTemplate) {
       this.skipMutationAttributes = true;
       return Queue.enqueue(() => {}).finally(() => {
         this.skipMutationAttributes = false;

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -715,8 +715,11 @@ export class ElementFragment extends Fragment {
     rawName: string,
     targetName: string,
     value: string | null,
+    fromObserver = false,
   ): Promise<void> {
-    return this.setAttributeInternal(rawName, targetName, value, false);
+    return this.setAttributeInternal(
+      rawName, targetName, value, false, fromObserver,
+    );
   }
 
   /**

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -767,6 +767,15 @@ export class ElementFragment extends Fragment {
       return this.removeAliasedAttribute(rawName, targetName);
     }
     const contents = new AttributeContents(rawName, value);
+    // MutationObserver経由で展開済みの値が渡された場合に、テンプレート式を含む既存エントリを上書きしない。
+    // （例: href="...{{customerCode}}..." が展開された後の値でattributeMapが破壊されるのを防ぐ）
+    const existing = this.attributeMap.get(rawName);
+    if (existing && (existing.isEvaluate || existing.isForceEvaluation()) && !contents.isEvaluate && !contents.isForceEvaluation()) {
+      this.skipMutationAttributes = true;
+      return Queue.enqueue(() => {}).finally(() => {
+        this.skipMutationAttributes = false;
+      }) as Promise<void>;
+    }
     this.attributeMap.set(rawName, contents);
     this.skipMutationAttributes = true;
     const element = this.getTarget();

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -75,6 +75,7 @@ export class Observer {
                 element,
                 mutation.attributeName!,
                 element.getAttribute(mutation.attributeName!),
+                true,
               );
               IntersectObserver.syncElement(element);
               break;

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -4,7 +4,7 @@
 
 import {vi} from 'vitest';
 import Core from '../src/core';
-import {ElementFragment} from '../src/fragment';
+import Fragment, {ElementFragment} from '../src/fragment';
 import {waitForCondition, waitForDomSettled} from './helpers/async';
 
 describe('Core', () => {
@@ -387,6 +387,34 @@ describe('Core', () => {
 
       // バインディング変更時も生値を維持したまま実属性だけ更新されること。
       expect(image.getAttribute('data-attr-src')).toBe('img/{{id}}.jpg');
+      expect(image.getAttribute('src')).toBe('img/after.jpg');
+    });
+
+    test('MutationObserver経由の書き戻しでdata-attr-*のattributeMapが上書きされない', async () => {
+      container.innerHTML = `
+        <img
+          data-bind='{"id":"before"}'
+          data-attr-src="img/{{id}}.jpg"
+          alt="preview"
+        >
+      `;
+
+      const image = container.querySelector('img') as HTMLImageElement;
+
+      await Core.scan(image);
+      await waitForDomSettled();
+
+      expect(image.getAttribute('src')).toBe('img/before.jpg');
+
+      // Observer経由の書き戻しをシミュレート: 展開済みの値でsetAttributeを呼ぶ
+      const fragment = Fragment.get(image) as ElementFragment;
+      await fragment.setAliasedAttribute('data-attr-src', 'src', 'img/before.jpg', true);
+      await waitForDomSettled();
+
+      // attributeMapのテンプレート式が保持され、再バインドで正しく展開されること。
+      await Core.setBindingData(image, {id: 'after'});
+      await waitForDomSettled();
+
       expect(image.getAttribute('src')).toBe('img/after.jpg');
     });
 


### PR DESCRIPTION
PR#17 の内容を復元したブランチです。\n\n- href 等にプレースホルダを含む属性を持つ要素で、MutationObserver 経由の展開済み値が attributeMap を上書きしないようにする修正です。\n- 既存の回帰テストで data-if と href 展開、data-fetch 経由のパスを確認しています。