### PR TITLE
data-if の非表示を inline style の !important に対応

### DIFF
--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -256,6 +256,9 @@ export class ElementFragment extends Fragment {
   /** 元の display 値 */
   private display: string | null = null;
 
+  /** 元の display の優先度 */
+  private displayPriority: string | null = null;
+
   /** each用のテンプレート */
   private template: ElementFragment | null = null;
 
@@ -365,6 +368,7 @@ export class ElementFragment extends Fragment {
     clone.clearBindingDataCache();
     clone.visible = true;
     clone.display = this.display;
+    clone.displayPriority = this.displayPriority;
     clone.template = this.template;
     clone.normalizeClonedVisibilityState();
     return clone;
@@ -380,8 +384,9 @@ export class ElementFragment extends Fragment {
       this.getTarget().hasAttribute(`${Env.prefix}if-false`)
     ) {
       this.visible = true;
-      this.display = '';
-      this.getTarget().style.display = '';
+      this.display = null;
+      this.displayPriority = null;
+      this.getTarget().style.removeProperty('display');
       this.getTarget().removeAttribute(`${Env.prefix}if-false`);
     }
     this.children.forEach(child => {
@@ -1137,9 +1142,11 @@ export class ElementFragment extends Fragment {
    */
   public hide(): Promise<void> {
     this.visible = false;
-    this.display = this.getTarget().style.display;
-    this.getTarget().style.display = 'none';
-    this.getTarget().setAttribute(`${Env.prefix}if-false`, '');
+    const target = this.getTarget();
+    this.display = target.style.getPropertyValue('display');
+    this.displayPriority = target.style.getPropertyPriority('display');
+    target.style.setProperty('display', 'none', 'important');
+    target.setAttribute(`${Env.prefix}if-false`, '');
     return Promise.resolve();
   }
 
@@ -1149,8 +1156,19 @@ export class ElementFragment extends Fragment {
    * @return エレメントの表示のPromise
    */
   public show(): Promise<void> {
-    this.getTarget().style.display = this.display ?? '';
-    this.getTarget().removeAttribute(`${Env.prefix}if-false`);
+    const target = this.getTarget();
+    if (this.display === null || this.display === '') {
+      target.style.removeProperty('display');
+    } else {
+      target.style.setProperty(
+        'display',
+        this.display,
+        this.displayPriority ?? '',
+      );
+    }
+    this.display = null;
+    this.displayPriority = null;
+    target.removeAttribute(`${Env.prefix}if-false`);
     this.visible = true;
     return Promise.resolve();
   }

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -1141,6 +1141,9 @@ export class ElementFragment extends Fragment {
    * @returns エレメントの非表示のPromise
    */
   public hide(): Promise<void> {
+    if (!this.visible) {
+      return Promise.resolve();
+    }
     this.visible = false;
     const target = this.getTarget();
     this.display = target.style.getPropertyValue('display');
@@ -1156,6 +1159,9 @@ export class ElementFragment extends Fragment {
    * @return エレメントの表示のPromise
    */
   public show(): Promise<void> {
+    if (this.visible) {
+      return Promise.resolve();
+    }
     const target = this.getTarget();
     if (this.display === null || this.display === '') {
       target.style.removeProperty('display');

--- a/tests/fragment.test.ts
+++ b/tests/fragment.test.ts
@@ -273,6 +273,24 @@ describe('ElementFragment の属性操作', () => {
     expect(clone.getTarget().hasAttribute('data-if-false')).toBe(false);
   });
 
+  it('hide() は display を important 付きで上書きし、show() で元に戻す', async () => {
+    const el = document.createElement('div');
+    el.style.setProperty('display', 'inline-flex');
+    const ef = new ElementFragment(el);
+
+    await ef.hide();
+
+    expect(el.style.getPropertyValue('display')).toBe('none');
+    expect(el.style.getPropertyPriority('display')).toBe('important');
+    expect(el.hasAttribute('data-if-false')).toBe(true);
+
+    await ef.show();
+
+    expect(el.style.getPropertyValue('display')).toBe('inline-flex');
+    expect(el.style.getPropertyPriority('display')).toBe('');
+    expect(el.hasAttribute('data-if-false')).toBe(false);
+  });
+
 });
 
 describe('TextFragment と CommentFragment', () => {

--- a/tests/fragment.test.ts
+++ b/tests/fragment.test.ts
@@ -275,7 +275,7 @@ describe('ElementFragment の属性操作', () => {
 
   it('hide() は display を important 付きで上書きし、show() で元に戻す', async () => {
     const el = document.createElement('div');
-    el.style.setProperty('display', 'inline-flex');
+    el.style.setProperty('display', 'inline-flex', 'important');
     const ef = new ElementFragment(el);
 
     await ef.hide();
@@ -284,10 +284,21 @@ describe('ElementFragment の属性操作', () => {
     expect(el.style.getPropertyPriority('display')).toBe('important');
     expect(el.hasAttribute('data-if-false')).toBe(true);
 
+    await ef.hide();
+    expect(el.style.getPropertyValue('display')).toBe('none');
+    expect(el.style.getPropertyPriority('display')).toBe('important');
+    expect(el.hasAttribute('data-if-false')).toBe(true);
+
     await ef.show();
 
     expect(el.style.getPropertyValue('display')).toBe('inline-flex');
-    expect(el.style.getPropertyPriority('display')).toBe('');
+    expect(el.style.getPropertyPriority('display')).toBe('important');
+    expect(el.hasAttribute('data-if-false')).toBe(false);
+
+    await ef.show();
+
+    expect(el.style.getPropertyValue('display')).toBe('inline-flex');
+    expect(el.style.getPropertyPriority('display')).toBe('important');
     expect(el.hasAttribute('data-if-false')).toBe(false);
   });
 


### PR DESCRIPTION
data-if で要素を非表示にする際、style.display = 'none' では d-inline-flex のような display: ... !important を持つクラスに負けてしまう問題を修正しました。

変更内容:
- hide() で display: none !important を inline style として設定するよう変更
- 元の display 値と優先度を保持し、show() で復元するよう変更
- hide()/show() の再入時に元値を上書きしないよう調整
- clone 時にも runtime の display 状態を引き継がないよう調整
- 回帰防止のテストを追加

確認結果:
- fragment.test.ts 成功
- core.test.ts 成功