### PR TITLE
click ロックの disabled 再付与を防止

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -342,6 +342,7 @@ export default class Core {
   public static setBindingData(
     element: HTMLElement,
     data: Record<string, unknown>,
+    skipFragments: ReadonlySet<ElementFragment> = new Set(),
   ): Promise<void> {
     const fragment = Fragment.get(element) as ElementFragment;
     const previous = fragment.getRawBindingData();
@@ -363,7 +364,7 @@ export default class Core {
             : data;
       chain = chain.then(() => Form.syncValues(fragment, formValues));
     }
-    chain = chain.then(() => Core.evaluateAll(fragment));
+    chain = chain.then(() => Core.evaluateAll(fragment, skipFragments));
 
     // bindchangeイベントを発火
     HaoriEvent.bindChange(element, previous, data, 'manual');
@@ -524,7 +525,13 @@ export default class Core {
    * @param fragment 対象フラグメント
    * @return Promise (DOM操作が完了したときに解決される)
    */
-  public static evaluateAll(fragment: ElementFragment): Promise<void> {
+  public static evaluateAll(
+    fragment: ElementFragment,
+    skipFragments: ReadonlySet<ElementFragment> = new Set(),
+  ): Promise<void> {
+    if (skipFragments.has(fragment)) {
+      return Promise.resolve();
+    }
     const promises: Promise<void>[] = [];
     promises.push(Core.reevaluateInterpolatedAttributes(fragment));
     if (fragment.hasAttribute(`${Env.prefix}if`)) {
@@ -535,7 +542,7 @@ export default class Core {
     }
     fragment.getChildren().forEach(child => {
       if (child instanceof ElementFragment) {
-        promises.push(Core.evaluateAll(child));
+        promises.push(Core.evaluateAll(child, skipFragments));
       } else if (child instanceof TextFragment) {
         promises.push(Core.evaluateText(child));
       }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -64,6 +64,14 @@ export class Observer {
               const element = mutation.target as HTMLElement;
               if (
                 mutation.attributeName &&
+                element.hasAttribute('data-haori-click-lock') &&
+                (mutation.attributeName === 'disabled' ||
+                  mutation.attributeName === 'data-haori-click-lock')
+              ) {
+                break;
+              }
+              if (
+                mutation.attributeName &&
                 Core.isAliasedAttributeReflection(
                   element,
                   mutation.attributeName,

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -1308,6 +1308,7 @@ ${body}
     if (
       Procedure.RUNNING_CLICK_TARGETS.has(target) ||
       target.matches(':disabled') ||
+      target.hasAttribute('disabled') ||
       target.hasAttribute(PROCEDURE_CLICK_LOCK_MARKER)
     ) {
       return false;

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -34,6 +34,9 @@ const PROCEDURE_HAORI_METHOD_NAMES = [
 
 const PROCEDURE_HISTORY_STATE_KEY = '__haoriHistoryState__';
 
+/** click ロック中であることを示す内部マーカー属性名 */
+const PROCEDURE_CLICK_LOCK_MARKER = 'data-haori-click-lock';
+
 /**
  * Procedure から利用する Haori API を解決します。
  * window.Haori が差し替えられている場合はそちらを優先します。
@@ -1261,6 +1264,14 @@ ${body}
         // 双方向バインディング: フォーム値を自動的にバインディングデータに反映
         const formFragment = this.options.formFragment;
         const formElement = formFragment.getTarget();
+        const skipFragments = new Set<ElementFragment>();
+        if (
+          executionLock &&
+          executionLock.appliedDisabledAttribute &&
+          this.options.targetFragment
+        ) {
+          skipFragments.add(this.options.targetFragment);
+        }
 
         formElement.setAttribute(
           `${Env.prefix}bind`,
@@ -1269,7 +1280,7 @@ ${body}
 
         const bindingData = formFragment.getBindingData();
         Object.assign(bindingData, payload);
-        await Core.setBindingData(formElement, bindingData);
+        await Core.setBindingData(formElement, bindingData, skipFragments);
       }
 
       const merged = hasPayload ? payload : {};
@@ -1292,15 +1303,18 @@ ${body}
       return null;
     }
 
-    const target = this.options.targetFragment.getTarget();
+    const targetFragment = this.options.targetFragment;
+    const target = targetFragment.getTarget();
     if (
       Procedure.RUNNING_CLICK_TARGETS.has(target) ||
-      target.hasAttribute('disabled')
+      target.matches(':disabled') ||
+      target.hasAttribute(PROCEDURE_CLICK_LOCK_MARKER)
     ) {
       return false;
     }
 
     Procedure.RUNNING_CLICK_TARGETS.add(target);
+    target.setAttribute(PROCEDURE_CLICK_LOCK_MARKER, '');
     target.setAttribute('disabled', '');
     return {
       target,
@@ -1324,6 +1338,7 @@ ${body}
     Procedure.RUNNING_CLICK_TARGETS.delete(executionLock.target);
     if (executionLock.appliedDisabledAttribute) {
       executionLock.target.removeAttribute('disabled');
+      executionLock.target.removeAttribute(PROCEDURE_CLICK_LOCK_MARKER);
     }
   }
 

--- a/tests/procedure-action-operations.test.ts
+++ b/tests/procedure-action-operations.test.ts
@@ -42,6 +42,41 @@ describe('Procedure action operations', () => {
     container.remove();
   });
 
+  it('data-click-form を伴う click 実行後に disabled 属性が残らない', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      return Promise.resolve(
+        new Response('{}', {headers: {'Content-Type': 'application/json'}}),
+      ) as unknown as Promise<Response>;
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const form = document.createElement('form');
+    form.id = 'search-form';
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.setAttribute('data-click-fetch', 'http://api.test/search');
+    button.setAttribute('data-click-form', '#search-form');
+    button.setAttribute('data-click-data', '{"page":0}');
+    button.setAttribute('data-click-history-form', '#search-form');
+    form.appendChild(button);
+    container.appendChild(form);
+
+    await waitForDomSettled();
+    button.click();
+
+    await waitForCondition(() => fetchSpy.mock.calls.length > 0, {
+      description: 'search fetch',
+    });
+    await waitForCondition(() => !button.hasAttribute('disabled'), {
+      description: 'search button re-enabled',
+    });
+
+    expect(button.hasAttribute('disabled')).toBe(false);
+    container.remove();
+  });
+
   it('refetchFragments invokes Procedure.run', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
       return Promise.resolve(

--- a/tests/procedure_events.test.ts
+++ b/tests/procedure_events.test.ts
@@ -202,6 +202,22 @@ describe('イベント属性: before-run / after-run', () => {
     expect(frag.getTarget().hasAttribute('disabled')).toBe(true);
   });
 
+  it('非 form control の click 要素でも disabled 属性があれば処理を開始しない', async () => {
+    const element = document.createElement('div');
+    element.setAttribute('disabled', '');
+    element.setAttribute('data-click-fetch', 'https://example.com/original');
+    container.appendChild(element);
+
+    const frag = Fragment.get(element) as ElementFragment;
+    const fetchMock = (global.fetch = vi.fn() as unknown as typeof fetch);
+
+    const proc = new Procedure(frag, 'click');
+
+    await expect(proc.runWithResult()).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(frag.getTarget().hasAttribute('disabled')).toBe(true);
+  });
+
   it('data-click-data のテンプレート式が評価された payload を送信する', async () => {
     const host = document.createElement('div');
     host.setAttribute('data-bind', '{"status":"active","priority":3}');


### PR DESCRIPTION
未対応アラート画面の検索ボタン/クリアボタンで、クリック後に disabled 属性が元に戻らない問題を修正しました。\n\n根因:\n- click 実行中のロック判定を :disabled のみで見ていたため、非 form control の disabled をロックとして扱えなくなっていました。\n- MutationObserver 側の一時ロック回避とあわせ、再入防止の意味を属性ベースで維持する必要がありました。\n\n対応:\n- 再入防止判定で :disabled に加えて disabled 属性も確認するよう修正\n- click ロックの内部マーカーは維持し、Observer には一時的な disabled 変更を引き続き無視させる\n- 非 form control の disabled 属性が処理開始前の抑止として機能する回帰テストを追加\n\n確認結果:\n- procedure_events.test.ts 成功\n- procedure-action-operations.test.ts 成功\n- click-attributes.test.ts 成功\n\n残る注意点:\n- `skipFragments` により click target 配下の再評価をまとめてスキップするため、クリック要素の子要素を動的に更新するケースは別途確認が必要です。